### PR TITLE
Fixed: incorrect provider name

### DIFF
--- a/modules/scw-ssh-key/versions.tf
+++ b/modules/scw-ssh-key/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0, < 2.0"
 
   required_providers {
-    azurerm = {
+    scaleway = {
       source  = "registry.opentofu.org/scaleway/scaleway"
       version = "2.38.2"
     }


### PR DESCRIPTION
***What does this change do?***

- The name of the scaleway provider was incorrect

***Why is this change needed?***

- Fix the scw-ssh-keys module