### PR TITLE
Added: Azure service principal and role bindings

### DIFF
--- a/modules/az-service-principal/outputs.tf
+++ b/modules/az-service-principal/outputs.tf
@@ -1,0 +1,4 @@
+output "client_secret" {
+  value     = "${azuread_service_principal.service_principal.display_name}:${azuread_application_password.secret_key.value}"
+  sensitive = true
+}

--- a/modules/az-service-principal/service-principal.tf
+++ b/modules/az-service-principal/service-principal.tf
@@ -1,0 +1,61 @@
+resource "azuread_application" "application" {
+  display_name = var.service_principal.az_ad_application_name
+}
+
+resource "azuread_service_principal" "service_principal" {
+  client_id                    = azuread_application.application.client_id
+  app_role_assignment_required = true
+  description                  = var.service_principal.description
+}
+
+resource "azuread_application_password" "secret_key" {
+  application_id    = azuread_application.application.id
+  end_date_relative = "${var.service_principal.hours_to_expiry}h"
+}
+
+resource "azurerm_role_definition" "custom_role" {
+  name        = var.service_principal.custom_role.name
+  description = var.service_principal.custom_role.description
+  scope       = "/subscriptions/${var.subscription_id}"
+
+  permissions {
+    actions          = var.service_principal.custom_role.permissions.actions
+    not_actions      = var.service_principal.custom_role.permissions.not_actions
+    data_actions     = var.service_principal.custom_role.permissions.data_actions
+    not_data_actions = var.service_principal.custom_role.permissions.not_data_actions
+  }
+
+  assignable_scopes = var.service_principal.custom_role.assignable_scopes
+}
+
+resource "azurerm_role_assignment" "role_assignment_custom" {
+  for_each = (
+    var.service_principal.role_type == "custom" ?
+    toset(var.service_principal.custom_role.assigned_scopes) :
+    toset([])
+  )
+
+  scope                            = each.value
+  role_definition_id               = azurerm_role_definition.custom_role.role_definition_resource_id
+  principal_id                     = azuread_service_principal.service_principal.id
+  skip_service_principal_aad_check = var.service_principal.skip_service_principal_aad_check
+}
+
+resource "azurerm_role_assignment" "role_assignment_builtin" {
+  for_each = (
+    var.service_principal.role_type == "builtin" ?
+    toset(var.service_principal.builtin_role.assigned_scopes) :
+    toset([])
+  )
+
+  scope                            = each.value
+  role_definition_name             = var.service_principal.builtin_role.name
+  principal_id                     = azuread_service_principal.service_principal.id
+  skip_service_principal_aad_check = var.service_principal.skip_service_principal_aad_check
+}
+
+// Eg to use a service principal in a k8s cluster definition
+// service_principal {
+//   client_id = azuread_service_principal.service_principal.client_id
+//   client_secret = azuread_application_password.secret_key.value
+// }

--- a/modules/az-service-principal/variables.tf
+++ b/modules/az-service-principal/variables.tf
@@ -1,0 +1,34 @@
+variable "service_principal" {
+  type = object({
+    az_ad_application_name           = string
+    hours_to_expiry                  = string
+    role_type                        = string
+    description                      = string
+    skip_service_principal_aad_check = bool
+    custom_role = object({
+      name              = string
+      assignable_scopes = list(string)
+      assigned_scopes   = list(string)
+      permissions = object({
+        actions          = list(string)
+        not_actions      = list(string)
+        data_actions     = list(string)
+        not_data_actions = list(string)
+      })
+      description = string
+    })
+    builtin_role = object({
+      name            = string
+      assigned_scopes = list(string)
+    })
+  })
+  validation {
+    condition     = contains(["custom", "builtin"], var.service_principal.role_type)
+    error_message = "The role type must be either `custom` or `builtin`"
+  }
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Id of the subscription scope for the role assignment"
+}

--- a/modules/az-service-principal/versions.tf
+++ b/modules/az-service-principal/versions.tf
@@ -3,12 +3,12 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
+      source  = "registry.opentofu.org/hashicorp/azurerm"
       version = "3.96.0"
     }
     azuread = {
-      source  = "hashicorp/azuread"
-      version = "2.35.0"
+      source  = "registry.opentofu.org/hashicorp/azuread"
+      version = "2.47.0"
     }
   }
 }


### PR DESCRIPTION
***What does this change do?***

- creates an application, an associated service principal and binds the service principal to roles - thereby creating an account with RBAC/IAM to execute actions via automation against the Azure infrastructure.

***Why is this change needed?***

- to have tofu create service principals automatically
- to be able to reference the service principals as tofu datasources