### PR TITLE
Added: modules to manage azure and scaleway dns

### DIFF
--- a/modules/az-dns-records/az_dns.tf
+++ b/modules/az-dns-records/az_dns.tf
@@ -1,0 +1,57 @@
+data "azurerm_resource_group" "az_resource_group" {
+  name = var.az_dns.az_resource_group
+}
+
+data "azurerm_dns_zone" "az_dns_zones" {
+  for_each = toset(keys(var.az_dns.dns_zones.azure))
+  name     = each.value
+}
+
+locals {
+  dns_a_records = flatten([
+    for dns_key, dns_val in var.az_dns.dns_zones.azure : [
+      for subdomain_val in dns_val.a_records : {
+        parent_domain = dns_key
+        sub_domain    = subdomain_val
+      }
+  ]])
+
+  dns_ns_redirects = flatten([
+    for dns_key, dns_val in var.az_dns.dns_zones.azure : {
+      dns_key = dns_key
+      dns_val = dns_val
+  }])
+}
+
+resource "azurerm_dns_ns_record" "az_ns_redirect" {
+  for_each = toset(keys({
+    for dns_zone in local.dns_ns_redirects : dns_zone.dns_key => dns_zone
+    if length(split(".", dns_zone.dns_key)) > 2
+  }))
+
+  name                = split(".", each.value)[0]
+  zone_name           = join(".", slice(split(".", each.value), 1, length(split(".", each.value))))
+  resource_group_name = data.azurerm_resource_group.az_resource_group.name
+  ttl                 = 300
+
+  records = data.azurerm_dns_zone.az_dns_zones[each.value].name_servers
+
+  tags = merge(var.az_dns.tags, { dns_zone = join(".", slice(split(".", each.value), 1, length(split(".", each.value)))), type = "NS Record" })
+}
+
+resource "azurerm_dns_a_record" "az_a_record" {
+  depends_on = [
+    azurerm_dns_ns_record.az_ns_redirect
+  ]
+  for_each = {
+    for dns_record in local.dns_a_records : "${dns_record.sub_domain}.${dns_record.parent_domain}" => dns_record
+    if local.dns_a_records != []
+  }
+
+  name                = each.value.sub_domain
+  zone_name           = each.value.parent_domain
+  resource_group_name = data.azurerm_resource_group.az_resource_group.name
+  ttl                 = 300
+  records             = [var.a_records_target_ip]
+  tags                = merge(var.az_dns.tags, { parent = each.value.parent_domain, type = "A Record" })
+}

--- a/modules/az-dns-records/variables.tf
+++ b/modules/az-dns-records/variables.tf
@@ -1,0 +1,18 @@
+variable "az_dns" {
+  type = object({
+    scw_loadbalancer_name_for_a_records = string
+    az_resource_group                   = string
+    dns_zones = object({
+      azure = map(object({
+        a_records = list(string)
+      }))
+    })
+    tags = map(string)
+  })
+  description = "Variables required to configure dns via azure"
+}
+
+variable "a_records_target_ip" {
+  type        = string
+  description = "Ip address of the target ip for the a records, usually a loadbalancer"
+}

--- a/modules/az-dns-records/versions.tf
+++ b/modules/az-dns-records/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0, < 2.0"
+
+  required_providers {
+    azurerm = {
+      source  = "registry.opentofu.org/hashicorp/azurerm"
+      version = "3.96.0"
+    }
+  }
+}

--- a/modules/az-dns-zones/az_dns.tf
+++ b/modules/az-dns-zones/az_dns.tf
@@ -1,0 +1,11 @@
+data "azurerm_resource_group" "az_resource_group" {
+  name = var.az_dns.az_resource_group
+}
+
+resource "azurerm_dns_zone" "az_dns_zones" {
+  for_each = toset(keys(var.az_dns.dns_zones.azure))
+
+  name                = each.value
+  resource_group_name = data.azurerm_resource_group.az_resource_group.name
+  tags                = merge(var.az_dns.tags, { dns_zone = each.value, type = "Azure DNS Zone" })
+}

--- a/modules/az-dns-zones/variables.tf
+++ b/modules/az-dns-zones/variables.tf
@@ -1,0 +1,13 @@
+variable "az_dns" {
+  type = object({
+    az_resource_group = string
+    dns_zones = object({
+      azure = map(object({
+        a_records = list(string)
+      }))
+    })
+    tags = map(string)
+  })
+  description = "Variables required to configure dns zones via azure"
+}
+

--- a/modules/az-dns-zones/versions.tf
+++ b/modules/az-dns-zones/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0, < 2.0"
+
+  required_providers {
+    azurerm = {
+      source  = "registry.opentofu.org/hashicorp/azurerm"
+      version = "3.96.0"
+    }
+  }
+}

--- a/modules/scw-az-ns-redirects/scw_dns.tf
+++ b/modules/scw-az-ns-redirects/scw_dns.tf
@@ -1,0 +1,29 @@
+data "azurerm_dns_zone" "az_dns_zones" {
+  for_each = toset(keys(var.scw_az_ns_redirects.dns_zones.scw))
+  name     = each.value
+}
+
+resource "scaleway_domain_record" "scw_ns_redirects_to_azure" {
+  for_each = {
+    for ns_record in flatten([
+      for zone in keys(var.scw_az_ns_redirects.dns_zones.scw) : [
+        // It's a range of 4 elements because terraform needs to know in advance
+        // Setting statically for 4 azure name servers for ns redirection
+        for idx in range(0, 4) : {
+          idx  = idx
+          key  = replace("${zone}-${idx}", ".", "-")
+          zone = zone
+        }
+      ]
+    ]) : ns_record.key => { idx = ns_record.idx, zone = ns_record.zone }
+    if var.scw_az_ns_redirects.dns_zones.scw[ns_record.zone].redirect_using_azure_ns_records == true
+  }
+
+  dns_zone        = each.value.zone
+  keep_empty_zone = false // will help ensure zone is deleted
+  priority        = 0
+  name            = each.key
+  type            = "NS"
+  data            = element(tolist(data.azurerm_dns_zone.az_dns_zones[each.value.zone].name_servers), each.value.idx)
+  ttl             = 1800
+}

--- a/modules/scw-az-ns-redirects/variables.tf
+++ b/modules/scw-az-ns-redirects/variables.tf
@@ -1,0 +1,11 @@
+variable "scw_az_ns_redirects" {
+  type = object({
+    az_resource_group = string
+    dns_zones = object({
+      scw = map(object({
+        redirect_using_azure_ns_records = bool
+      }))
+    })
+  })
+  description = "Variables required to configure dns via azure and scaleway"
+}

--- a/modules/scw-az-ns-redirects/versions.tf
+++ b/modules/scw-az-ns-redirects/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0, < 2.0"
+
+  required_providers {
+    azurerm = {
+      source  = "registry.opentofu.org/hashicorp/azurerm"
+      version = "3.96.0"
+    }
+    scaleway = {
+      source  = "registry.opentofu.org/scaleway/scaleway"
+      version = "2.38.3"
+    }
+  }
+}

--- a/modules/scw-dns/scw_dns.tf
+++ b/modules/scw-dns/scw_dns.tf
@@ -1,0 +1,88 @@
+resource "scaleway_domain_zone" "scw_dns_zones" {
+  depends_on = []
+
+  for_each = {
+    for record in flatten([
+      for zone in keys(var.scw_dns.dns_zones) : [
+        {
+          key        = replace(zone, ".", "-")
+          zone       = zone
+          a_records  = var.scw_dns.dns_zones[zone].a_records
+          project_id = var.scw_dns.dns_zones[zone].project_id
+        }
+      ]
+    ]) : record.key => { zone = record.zone, a_records = record.a_records, project_id = record.project_id }
+    // only create a subdomain for non-root zones
+    if length(split(".", record.zone)) > 2
+  }
+
+  domain = (
+    replace(
+      each.value.zone,
+      "${element(split(".", each.value.zone), 0)}.",
+      ""
+    )
+  )
+  subdomain  = element(split(".", each.value.zone), 0)
+  project_id = each.value.project_id
+}
+
+resource "scaleway_domain_record" "scw_a_records" {
+  depends_on = [scaleway_domain_zone.scw_dns_zones]
+
+  for_each = {
+    for record in flatten([
+      for zone in keys(var.scw_dns.dns_zones) : [
+        for a_rec_name, a_rec_ip in var.scw_dns.dns_zones[zone].a_records : [
+          {
+            key           = a_rec_name != "" ? "${a_rec_name}.${replace(zone, ".", "-")}" : replace(zone, ".", "-")
+            zone          = zone
+            a_record_name = a_rec_name
+            a_record_ip   = a_rec_ip
+          }
+        ]
+      ]
+      ]) : record.key => {
+      zone          = record.zone,
+      a_record_name = record.a_record_name,
+      a_record_ip   = record.a_record_ip
+    }
+  }
+
+  dns_zone        = each.value.zone
+  keep_empty_zone = false // will help ensure zone is deleted
+  priority        = 0
+  name            = each.value.a_record_name
+  type            = "A"
+  data            = each.value.a_record_ip
+  ttl             = 1800
+}
+
+resource "scaleway_domain_record" "scw_cname_records" {
+  depends_on = [scaleway_domain_zone.scw_dns_zones, scaleway_domain_record.scw_a_records]
+
+  for_each = {
+    for record in flatten([
+      for zone in keys(var.scw_dns.dns_zones) : [
+        for cname_rec_src, cname_rec_dest in var.scw_dns.dns_zones[zone].cname_records : [
+          {
+            key               = "${replace(cname_rec_src, ".", "-")}-${zone}"
+            zone              = zone
+            cname_record_src  = cname_rec_src
+            cname_record_dest = cname_rec_dest
+          }
+        ]
+      ]
+      ]) : record.key => {
+      zone              = record.zone,
+      cname_record_src  = record.cname_record_src
+      cname_record_dest = record.cname_record_dest
+    }
+  }
+
+  dns_zone = each.value.zone
+  name     = each.value.cname_record_src
+  type     = "CNAME"
+  data     = "${each.value.cname_record_dest}."
+  ttl      = 1800
+}

--- a/modules/scw-dns/variables.tf
+++ b/modules/scw-dns/variables.tf
@@ -1,0 +1,12 @@
+variable "scw_dns" {
+  type = object({
+    dns_zones = map(
+      object({
+        a_records     = map(string)
+        cname_records = map(string)
+        project_id    = string
+      })
+    )
+  })
+  description = "Variables required to configure dns via scaleway"
+}

--- a/modules/scw-dns/versions.tf
+++ b/modules/scw-dns/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0, < 2.0"
+
+  required_providers {
+    scaleway = {
+      source  = "registry.opentofu.org/scaleway/scaleway"
+      version = "2.38.3"
+    }
+  }
+}


### PR DESCRIPTION
***What does this change do?***

- Added module to create ns redirects from scaleway root zones to azure root zones.
- Added module to create scaleway zones and domain records
- Added module to create azure dns zones and domain a records

***Why is this change needed?***

- Manage dns using a combination of azure and scaleway
- Azure was needed additionally because inside kubernetes tools like cert-manager need access through a service principal to make automated dns challenges and afaik this is not yet possible in scalway