### PR TITLE
Changed: option ignore net-rules for az key vault

### DIFF
--- a/examples/az-resource-groups/main.tf
+++ b/examples/az-resource-groups/main.tf
@@ -1,6 +1,6 @@
 // Azure Resources
 module "az_resource_groups" {
-  source = "git::https://github.com/eirenauts/tf-modules.git//modules/az-resource-group?ref=0.0.6"
+  source = "git::https://github.com/eirenauts/tf-modules.git//modules/az-resource-group?ref=0.12.0"
   // source = "../../modules/az-resource-group"
 
   for_each = var.az_resource_groups

--- a/examples/cloud-iam/main.tf
+++ b/examples/cloud-iam/main.tf
@@ -1,6 +1,6 @@
 // Scaleway SSH Keys
 module "scw_ssh_keys" {
-  source = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-ssh-key?ref=0.0.6"
+  source = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-ssh-key?ref=0.12.0"
   //  source = "../../tf-modules/modules/scw-ssh-key"
 
   for_each    = var.scw_ssh_keys
@@ -9,7 +9,7 @@ module "scw_ssh_keys" {
 
 // Create Azure Service Principals
 module "az_service_principals" {
-  source = "git::https://github.com/eirenauts/tf-modules.git//modules/az-service-principal?ref=0.0.6"
+  source = "git::https://github.com/eirenauts/tf-modules.git//modules/az-service-principal?ref=0.12.0"
   // source = "../../tf-modules/modules/az-service-principal"
 
   for_each = {
@@ -23,7 +23,7 @@ module "az_service_principals" {
 
 //// Create scaleway iam applications with policies set
 module "scw_iam" {
-  source = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-iam?ref=0.0.6"
+  source = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-iam?ref=0.12.0"
   // source = "../../tf-modules/modules/scw-iam"
 
   for_each = var.scw_iam
@@ -40,7 +40,7 @@ module "scw_iam" {
 
 // Create azure key vaults
 module "az_key_vaults" {
-  source = "git::https://github.com/eirenauts/tf-modules.git//modules/az-key-vault?ref=0.0.6"
+  source = "git::https://github.com/eirenauts/tf-modules.git//modules/az-key-vault?ref=0.12.0"
   // source   = "../../tf-modules/modules/az-key-vault"
   for_each = var.az_key_vaults
 
@@ -54,7 +54,7 @@ module "az_key_vaults" {
 // Azure secret storage of the scaleway iam api keys
 module "az_scw_iam_secrets" {
   depends_on = [module.az_key_vaults, module.scw_iam]
-  source     = "git::https://github.com/eirenauts/tf-modules.git//modules/az-key-vault-secret?ref=0.0.6"
+  source     = "git::https://github.com/eirenauts/tf-modules.git//modules/az-key-vault-secret?ref=0.12.0"
   // source     = "../../tf-modules/modules/az-key-vault-secret"
 
   for_each = var.az_scw_iam_secrets

--- a/examples/cloud-iam/terraform.auto.tfvars.enc.json
+++ b/examples/cloud-iam/terraform.auto.tfvars.enc.json
@@ -1,25 +1,4 @@
 {
-	"global_tags": {
-		"environment": "test",
-		"managed-by": "terraform",
-		"triggered-by": "user-principal-stephen-moloney",
-		"project": "az-multicloud-iam",
-		"purpose": "Demonstrating azure key vault and scaleway iam usage",
-		"source-dir": "examples/multicloud-iam",
-		"source-repo": "https://github.com/eirenauts/tf-modules.git"
-	},
-	"azure": {
-		"az_ad_application_name": "_redacted_",
-		"client_secret_enc": "ENC[AES256_GCM,data:N1xdRlxl2WdoHw==,iv:rJWAk6mEbqoCR7lLdHCu/9hVvBnQclbpvGGzL/ewp7o=,tag:Fogyln4+T9FSsFIIkHzaUg==,type:str]",
-		"subscription_id": "_redacted_",
-		"tenant_id": "_redacted_"
-	},
-	"terraform_backend": {
-		"storage_account_name": "_redacted_",
-		"storage_account_resource_group": "_redacted_",
-		"storage_container_key": "default.tfstate",
-		"storage_container_name": "az-multicloud-iam"
-	},
 	"az_key_vaults": {
 		"multicloud_iam_kv": {
 			"access_policies": [
@@ -137,18 +116,19 @@
 			"sku": "standard",
 			"tags": {
 				"purpose": "key-vault to be consumed by applications and other terraform projects"
-			}
+			},
+			"tf_ignore_network_rules": false
 		}
 	},
 	"az_scw_iam_secrets": {
 		"scw_multicloud_iam_access_key": {
-			"name": "scw-multicloud-iam-access-key",
 			"content_type": "text/plain",
 			"expires": false,
 			"expiry_day": null,
 			"expiry_month": null,
 			"expiry_year": null,
 			"iam_key": "scw_multicloud_iam_key",
+			"name": "scw-multicloud-iam-access-key",
 			"resource_group": "tf-modules-az-rg-1",
 			"tags": {
 				"purpose": "Access key for scaleway iam to access s3 object storage"
@@ -156,13 +136,13 @@
 			"vault": "az-multicloud-key-vault"
 		},
 		"scw_multicloud_iam_secret_key": {
-			"name": "scw-multicloud-iam-secret-key",
 			"content_type": "text/plain",
 			"expires": false,
 			"expiry_day": null,
 			"expiry_month": null,
 			"expiry_year": null,
 			"iam_key": "scw_multicloud_iam_key",
+			"name": "scw-multicloud-iam-secret-key",
 			"resource_group": "tf-modules-az-rg-1",
 			"tags": {
 				"purpose": "Secret key for scaleway iam to access s3 object storage"
@@ -221,12 +201,27 @@
 			"skip_service_principal_aad_check": false
 		}
 	},
+	"azure": {
+		"az_ad_application_name": "_redacted_",
+		"client_secret_enc": "ENC[AES256_GCM,data:+SFTllc2fA8OlQ==,iv:ArEN01XYTCd4T9/IEUtlhxfF9dmHlT7+2ubbLUJ0nKo=,tag:A8P6Xb5F5SSOLu4yw9lebw==,type:str]",
+		"subscription_id": "_redacted_",
+		"tenant_id": "_redacted_"
+	},
+	"global_tags": {
+		"environment": "test",
+		"managed-by": "terraform",
+		"project": "az-multicloud-iam",
+		"purpose": "Demonstrating azure key vault and scaleway iam usage",
+		"source-dir": "examples/multicloud-iam",
+		"source-repo": "https://github.com/eirenauts/tf-modules.git",
+		"triggered-by": "user-principal-stephen-moloney"
+	},
 	"scaleway": {
-		"access_key_enc": "ENC[AES256_GCM,data:cC7vmgY70GBqZA==,iv:t9Jux16Kjbk7jFzeirRnegVmX5x3GobfaW9l0JepyGk=,tag:sCpKCc76khM1Zb88ye0RvQ==,type:str]",
+		"access_key_enc": "ENC[AES256_GCM,data:RDRAVy9UjVL41Q==,iv:I8jJWKs3FFT/NzLfJaJnmzQ9sI9jCvWSQiZg2IgUR2s=,tag:X4UaVD60Gs1XH2e+KmuMdw==,type:str]",
 		"organization_id": "_redacted_",
 		"project_id": "_redacted_",
 		"region": "_redacted_",
-		"secret_key_enc": "ENC[AES256_GCM,data:XXxEMJp6hpXtgw==,iv:yfXB5u3/OmWNuJABuSxbHZuunAZq4bxiN6dBs7fpH8I=,tag:DXKDua0+SiPeNzkgfkB4FA==,type:str]",
+		"secret_key_enc": "ENC[AES256_GCM,data:J0Gxeno8Z2Evhw==,iv:WZOuIp6zff5DxFSsNxP7phPvYUGdTlUURt0uuCBfj2E=,tag:SG6PIyMToVIMKHogBYosZQ==,type:str]",
 		"zone": "_redacted_"
 	},
 	"scw_iam": {
@@ -257,35 +252,41 @@
 	},
 	"scw_ssh_keys": {
 		"automation_git_read_only": {
+			"disabled": false,
 			"name": "git_read_only_01_ssh_key",
 			"notes": "Read access to repos in the git server for automation purposes",
-			"private_key_enc": "ENC[AES256_GCM,data:wahZEe1+iKSTMQ==,iv:/EbJL3xzm8yzzucvcLNdcc58xzOReLVQkJEUK3Ms+80=,tag:X31JfpG+95+sJB3CK7Fi3w==,type:str]",
+			"private_key_enc": "ENC[AES256_GCM,data:ritvl4lM8rIPhA==,iv:O4u1coMq70JNfIW7Ra+qU8XsN6GbC4RiLZE1EJ/yWJ8=,tag:qmOJrzIJoWv0hc8LYbvh7A==,type:str]",
 			"project_id": "_redacted_",
-			"public_key_enc": "ENC[AES256_GCM,data:TxpbJhy0q7PgzA==,iv:5UbY8kgP0L9GaMC6SCJofAyt4k8U9X2a2W2DBma0+do=,tag:+/7zLni7rd16YgB/V/JENQ==,type:str]",
-			"disabled": false
+			"public_key_enc": "ENC[AES256_GCM,data:UoRmPi+DTiaW6w==,iv:QiUMKLFBg0c/vr+R37IOFJE3Mm2QGGbNwGX7CkkfLpE=,tag:ukb5EG+G6b6nMDsJsQK2Iw==,type:str]"
 		},
 		"my_ssh_key": {
+			"disabled": false,
 			"name": "my_ssh_key",
 			"notes": "ssh access to servers for personal purposes",
 			"private_key_enc": null,
 			"project_id": "_redacted_",
-			"public_key_enc": "ENC[AES256_GCM,data:UyqA40Uk29uAMQ==,iv:aCh35d95LxwGGyIyTsdZhKFaQn6PM96Kj4IDd+PgesI=,tag:cXR8d4YaqFetMSUNSbxebA==,type:str]",
-			"disabled": false
+			"public_key_enc": "ENC[AES256_GCM,data:1swokxHH4nuMNA==,iv:2/q1oWx/CHBuIeyEg3NgHSGc/pzn5GrWmQ6C3pinLKw=,tag:Ms5V3WTWiY9BCYI9/JLbmQ==,type:str]"
 		}
 	},
 	"sops_pgp_fingerprint": "21583B31C30CB8BE31418483FC6E9A7735295C2B",
+	"terraform_backend": {
+		"storage_account_name": "_redacted_",
+		"storage_account_resource_group": "_redacted_",
+		"storage_container_key": "default.tfstate",
+		"storage_container_name": "az-multicloud-iam"
+	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-03-31T14:47:47Z",
-		"mac": "ENC[AES256_GCM,data:6o/HTshgfHae9IPXrWCBb/j7fNBbBabkcD4b420SOI49oCzu4MfbuNZLCEosd1BtcwgE5KpuHBcgpermH469FAbnYTGz6n6+rm7soBb2aj0jNjEJi0ElEZtlMS41Fd3oxTsnEasSZHRMSQv/DKARb6djVMU0HFikA/5W074/6qc=,iv:TaNbePAoZIC42TtRi+CPeMJ+9FYbPO3UZTGakjQEhbE=,tag:vMD+J+qliz08a3xxAHZLpA==,type:str]",
+		"lastmodified": "2024-04-13T10:03:58Z",
+		"mac": "ENC[AES256_GCM,data:3VInWieRiRzI4URxaUkRKslAsaf5wyz4H3U4RhD9LWeTPnQgamcmV9Xp64Ni0kEurpXuHrXznfVsuA3PROFb3cJ6KQxR621G8RoLerHRQboRaWFBMc5bIHCrv/q7SGykrl3Boj8qXZtZ3/SIwIzx5N5cHsrF1i0tz2QK0jI2UiM=,iv:TvbCIQQi0p3sPcj6OjMIsq5Wf6M8hMfyYF61dK+fZu0=,tag:V+RlyjT0XV1yDUwRB+LiPQ==,type:str]",
 		"pgp": [
 			{
-				"created_at": "2024-03-31T14:47:47Z",
-				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQIMAx3f3zFZ2uXWAQ/+MAOQ2973CV57wxzGU+QiN+9QFLe/EdfRp2QIBxxTTqWO\nlTcEzWVtdis6quOEIiGuQGNZuLqbO0AdN14iKrkoWbHi2ApzV7Y8eTvwXA0toSFs\nt55n2ng9jaXFDs2PWLxdR2MRA2zB1sw0DpTLWsuL/YxM3kUTp2msS9keajusEfuS\na8lVETLnpvADOH/7bHpdttVB6Xz3nSdHfSdRIQORKLrMZkBO3JJJQhDqXOSiweai\nR59hsqZowa0SuuHNes3CjfSXf9R6piXkCZ2TrQ3mEIOecybGa9U5KLq/hfYexfMH\npD4LLEXf6FhWbOUOUpiUB98NbFeiXYTPL9y3mGzO+BqG6JUdowFy/2JWhfkOcsCT\nRcXEk+i7l/b3Y1JJMxd/XL6YZU/Gb2ZfTFkbt7IpIio6ituGAgK1heCE2dM4bpl7\nU3i/adjaPENR0UMKU+T6GNCLP16movImeM/u5tdgRzy3N1Ff2zhBr44P2F/I/A5b\nP4hL3FY2LPEpNb/MKhp1KfFWy7Y4rwxrUpvP+Sa6L5eY30UT+xd9NjwKMY38LrZy\nauWRuS6MSe24iaAeu5V3xBQ57fWeurhCwTK5ZZ7qGEb3s5xsGGD5E3zRLdeUOpA+\nnrucPfoA6T02zaUD+GDqAkio+Yg7eYDn+wfXWbccfTMg37m9bKIUPAwo8H1MNvLS\nXgGzxRHd6nbsoL3TiX6j69PAujBCqjMu8uH+71T/gVpT2ccUP7ddCFq0Aq98LRAJ\nrQfCpPVAgHv2fBSj+PPe00F5hv3TtnPXCXWWBpV9OSDeyKnipElI3PMKN0e+lZU=\n=129S\n-----END PGP MESSAGE-----",
+				"created_at": "2024-04-13T10:03:58Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQIMAx3f3zFZ2uXWAQ/9EgE6kepNgdIcnICukzhJ84FD23FgrE+fyaucDVY8ti1M\n5SDS9mi0KnSSYXRGl/+bogamfrLBvC1BwVUY/1WYOcfSSqozIClW1BPRCYXD/vib\nOez66h+pQ8/EeHi4FBPTTwFrnBetNZp4deFPoEvpZCWZbqcp6Qo7m1KEJ7fVIWKU\nuuKimic6AqLkBk7XBfy+iWm3VdXPnatS6ZM+zK04bGu8Ktl9+3rqu0fVdkm6xvLd\n2OgQ29GxTrKEk5JPQMN/Gkd05wJlcuzGOPiU9pe8i1UQbYsYNE8TEv3oxJ5I4se/\nWJqgMmpbrA+m8+0eF5Sw+coHsPEuv8HzIF8/Zy/p+YfiJHmE8qXl2dC4uqCX7NzC\n7mOTbBBm3acCo13Bws8N89q54wMQYUtAtlxGT9WCIc31RJTTnQctXU9ZJOqBXCNT\nJAZWUQCKfvgvsk+K1RUqV9ontlCadSICAqpTmMJaBinOmsmkOMGkV5R0BdGa7KIl\nHT4y02jazfU3dH894seUaEn/7KnqzbaBqlkBMv+ELTjFWpXxINlZ6gHOFHOhQ7tY\nE/MSeL50XqutvADCkfbokGNYEL4Utk6Pz8exKiZFViwo/TwqGCeLEihmc5bRoXBl\njR5QxNRQyHI3vYrW9Bh/nJDSqQ517VriwA6JxNc/HQ5Za+yxH6B6CiMggcheeALS\nXgEspTRwvPzKlqfCip8oB3AfjQobvm63ift5N/wAJE1TgAThrTt2N+h3H8aDcwBy\n1lhfAoN+Wl4VJuGCL0RJUqFxjp75gFOmWPFU45LEtRha854zRYPToBvc7mGdixk=\n=F5Es\n-----END PGP MESSAGE-----",
 				"fp": "21583B31C30CB8BE31418483FC6E9A7735295C2B"
 			}
 		],

--- a/examples/cloud-iam/variables.tf
+++ b/examples/cloud-iam/variables.tf
@@ -137,6 +137,7 @@ variable "az_key_vaults" {
       bypass                     = string
     }))
     tags = map(string)
+    tf_ignore_network_rules = bool
   }))
 }
 

--- a/examples/cloud-networking/main.tf
+++ b/examples/cloud-networking/main.tf
@@ -1,6 +1,6 @@
 // Scaleway Networking
 module "scw_public_gateways" {
-  source = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-gateway?ref=0.0.7"
+  source = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-gateway?ref=0.12.0"
   // source = "../../../../../../open/tf-modules/modules/scw-gateway"
 
   for_each = var.scw_public_gateways
@@ -16,7 +16,7 @@ module "scw_public_gateways" {
 // Scaleway Private Network
 module "scw_vpcs" {
   depends_on = [module.scw_public_gateways]
-  source     = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-vpc?ref=0.0.7"
+  source     = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-vpc?ref=0.12.0"
   // source     = "../../../../../../open/tf-modules/modules/scw-vpc"
 
   for_each = var.scw_vpcs
@@ -32,7 +32,7 @@ module "scw_vpcs" {
 // Scaleway Loadbalancer
 module "scw_loadbalancers" {
   depends_on = [module.scw_vpcs]
-  source     = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-loadbalancer?ref=0.0.7"
+  source     = "git::https://github.com/eirenauts/tf-modules.git//modules/scw-loadbalancer?ref=0.12.0"
   // source     = "../../../../../../open/tf-modules/modules/scw-loadbalancer"
 
   for_each = var.scw_loadbalancers

--- a/modules/az-key-vault/main.tf
+++ b/modules/az-key-vault/main.tf
@@ -1,4 +1,6 @@
 resource "azurerm_key_vault" "az_key_vault" {
+  count = var.az_key_vault.tf_ignore_network_rules ? 0 : 1
+
   name                = var.az_key_vault.name
   resource_group_name = var.az_key_vault.resource_group
   # Note: location name expected, not name, get display names using cli
@@ -15,10 +17,45 @@ resource "azurerm_key_vault" "az_key_vault" {
     for_each = var.az_key_vault.network_rules
     content {
       default_action             = network_acls.value.default_action
-      ip_rules                   = network_acls.value.ip_rules
+      ip_rules                   = concat(network_acls.value.ip_rules, var.az_key_vault_adjunctive_ip_rules)
       virtual_network_subnet_ids = network_acls.value.virtual_network_subnet_ids
       bypass                     = network_acls.value.bypass
     }
+  }
+}
+
+resource "azurerm_key_vault" "az_key_vault_ignore_net_rules" {
+  count = var.az_key_vault.tf_ignore_network_rules ? 1 : 0
+
+  name                = var.az_key_vault.name
+  resource_group_name = var.az_key_vault.resource_group
+  # Note: location name expected, not name, get display names using cli
+  # az account list-locations | jq -r .[].name
+  # az account list-locations | jq -r .[].displayName
+  # az account list-locations --query "[].{DisplayName:displayName, Name:name}[?Name=='northeurope']" -o json | jq -r .[0].DisplayName
+  location                 = var.az_key_vault.location
+  sku_name                 = var.az_key_vault.sku
+  tenant_id                = var.az_tenant_id
+  purge_protection_enabled = var.az_key_vault.enable_purge_protection
+  tags                     = var.az_key_vault.tags
+
+  dynamic "network_acls" {
+    for_each = var.az_key_vault.network_rules
+    content {
+      default_action             = network_acls.value.default_action
+      ip_rules                   = concat(network_acls.value.ip_rules, var.az_key_vault_adjunctive_ip_rules)
+      virtual_network_subnet_ids = network_acls.value.virtual_network_subnet_ids
+      bypass                     = network_acls.value.bypass
+    }
+  }
+
+  // Ignoring the network rules because later they are going to be modified
+  // to include created instances
+  // Otherwise, get a lot of thrashing with terraform changes over and back
+  lifecycle {
+    ignore_changes = [
+      network_acls
+    ]
   }
 }
 
@@ -26,7 +63,7 @@ locals {
   access_policies_params = [
     for access_policy in var.az_key_vault.access_policies : {
       vault_key         = var.az_key_vault.name
-      vault_id          = azurerm_key_vault.az_key_vault.id
+      vault_id          = var.az_key_vault.tf_ignore_network_rules ? azurerm_key_vault.az_key_vault_ignore_net_rules[0].id : azurerm_key_vault.az_key_vault[0].id
       access_policy_key = access_policy.principal_name
       access_policy     = access_policy
     }
@@ -52,9 +89,33 @@ data "azuread_user" "az_user_principal" {
 
 resource "azurerm_key_vault_access_policy" "az_service_principal_access_policies" {
   depends_on = [azurerm_key_vault.az_key_vault]
+
   for_each = {
     for access_policy in local.access_policies_params : "${access_policy.vault_key}.${access_policy.access_policy_key}" => access_policy
-    if access_policy.access_policy.type == "service-principal"
+    if access_policy.access_policy.type == "service-principal" && (var.az_key_vault.tf_ignore_network_rules == false)
+  }
+
+  key_vault_id            = each.value.vault_id
+  tenant_id               = var.az_tenant_id
+  object_id               = data.azuread_service_principal.az_service_principal[each.key].object_id
+  key_permissions         = each.value.access_policy.key_permissions
+  secret_permissions      = each.value.access_policy.secret_permissions
+  certificate_permissions = each.value.access_policy.certificate_permissions
+  storage_permissions     = each.value.access_policy.storage_permissions
+
+  lifecycle {
+    ignore_changes = [
+      object_id
+    ]
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "az_service_principal_access_policies_ignore_net_rules" {
+  depends_on = [azurerm_key_vault.az_key_vault_ignore_net_rules]
+
+  for_each = {
+    for access_policy in local.access_policies_params : "${access_policy.vault_key}.${access_policy.access_policy_key}" => access_policy
+    if access_policy.access_policy.type == "service-principal" && var.az_key_vault.tf_ignore_network_rules
   }
 
   key_vault_id            = each.value.vault_id
@@ -77,7 +138,7 @@ resource "azurerm_key_vault_access_policy" "az_user_principal_access_policies" {
 
   for_each = {
     for access_policy in local.access_policies_params : "${access_policy.vault_key}.${access_policy.access_policy_key}" => access_policy
-    if access_policy.access_policy.type == "user-principal"
+    if access_policy.access_policy.type == "user-principal" && (var.az_key_vault.tf_ignore_network_rules == false)
   }
 
   key_vault_id            = each.value.vault_id
@@ -95,22 +156,34 @@ resource "azurerm_key_vault_access_policy" "az_user_principal_access_policies" {
   }
 }
 
-# Azure Cloud seems to lag following first time creation of the vault
-# So usings a yucky timeout
-resource "time_sleep" "wait_1_minutes" {
-  depends_on = [
-    azurerm_key_vault_access_policy.az_service_principal_access_policies,
-    azurerm_key_vault_access_policy.az_user_principal_access_policies
-  ]
+resource "azurerm_key_vault_access_policy" "az_user_principal_access_policies_ignore_net_rules" {
+  depends_on = [azurerm_key_vault.az_key_vault_ignore_net_rules]
 
-  create_duration = "1m"
+  for_each = {
+    for access_policy in local.access_policies_params : "${access_policy.vault_key}.${access_policy.access_policy_key}" => access_policy
+    if access_policy.access_policy.type == "user-principal" && var.az_key_vault.tf_ignore_network_rules
+  }
+
+  key_vault_id            = each.value.vault_id
+  tenant_id               = var.az_tenant_id
+  object_id               = data.azuread_user.az_user_principal[each.key].object_id
+  key_permissions         = each.value.access_policy.key_permissions
+  secret_permissions      = each.value.access_policy.secret_permissions
+  certificate_permissions = each.value.access_policy.certificate_permissions
+  storage_permissions     = each.value.access_policy.storage_permissions
+
+  lifecycle {
+    ignore_changes = [
+      object_id
+    ]
+  }
 }
 
 locals {
   rsa_params = [
     for rsa_key in var.az_key_vault.rsa_keys : {
       vault_key = var.az_key_vault.name
-      vault_id  = azurerm_key_vault.az_key_vault.id
+      vault_id  = var.az_key_vault.tf_ignore_network_rules ? azurerm_key_vault.az_key_vault_ignore_net_rules[0].id : azurerm_key_vault.az_key_vault[0].id
       rsa_key   = rsa_key.name
       name      = rsa_key.name
       type      = rsa_key.type
@@ -122,11 +195,30 @@ locals {
 
 resource "azurerm_key_vault_key" "az_rsa_key" {
   depends_on = [
-    time_sleep.wait_1_minutes
+    azurerm_key_vault.az_key_vault
   ]
 
   for_each = {
     for rsa_key in local.rsa_params : "${rsa_key.vault_key}.${rsa_key.rsa_key}" => rsa_key
+    if var.az_key_vault.tf_ignore_network_rules == false
+  }
+
+  key_vault_id = each.value.vault_id
+  name         = each.value.name
+  key_type     = each.value.type
+  key_size     = each.value.size
+  key_opts     = each.value.opts
+}
+
+
+resource "azurerm_key_vault_key" "az_rsa_key_ignore_net_rules" {
+  depends_on = [
+    azurerm_key_vault.az_key_vault_ignore_net_rules
+  ]
+
+  for_each = {
+    for rsa_key in local.rsa_params : "${rsa_key.vault_key}.${rsa_key.rsa_key}" => rsa_key
+    if var.az_key_vault.tf_ignore_network_rules
   }
 
   key_vault_id = each.value.vault_id

--- a/modules/az-key-vault/variables.tf
+++ b/modules/az-key-vault/variables.tf
@@ -5,6 +5,7 @@ variable "az_key_vault" {
     enable_purge_protection = string
     resource_group          = string
     location                = string
+    tf_ignore_network_rules = bool
     rsa_keys = list(object({
       name     = string
       type     = string
@@ -33,4 +34,10 @@ variable "az_tenant_id" {
   type        = string
   description = "Azure cloud tenant id in use"
   sensitive   = true
+}
+
+variable "az_key_vault_adjunctive_ip_rules" {
+  type        = list(string)
+  description = "Adjunctive ip rules to whitelist to the azure key vault"
+  default     = []
 }

--- a/modules/scw-k8s-cluster/cluster.tf
+++ b/modules/scw-k8s-cluster/cluster.tf
@@ -92,6 +92,11 @@ resource "scaleway_k8s_pool" "scw_k8s_cluster_pools" {
   region                 = var.scw_k8s_region
   wait_for_pool_ready    = each.value.wait_for_pool_ready
   placement_group_id     = scaleway_instance_placement_group.scw_k8s_placement_groups[each.value.placement_group.name].id
+
+  timeouts {
+    create = "30m"
+    update = "30m"
+  }
 }
 
 resource "local_file" "scw_k8s_kubeconfig" {


### PR DESCRIPTION
***What does this change do?***

- Implements logic that optionally ignores the network rules for the azure key vault
- Added timeout for k8s scaleway cluster creation

***Why is this change needed?***

- Because I need the feature to add more ip address whitelisting after the initial creation of the azure key vault and make those changes using a script. To avoid terraform recreating or modifying the object in an over and back manner, we just ignore the network rules instead. So only the first time will the network rules be applied when they are being ignored